### PR TITLE
Tracing on output and df variable names

### DIFF
--- a/bifrost_tracing/__init__.py
+++ b/bifrost_tracing/__init__.py
@@ -5,15 +5,16 @@ __email__ = 'aju960219@gmail.com'
 __version__ = '0.1.0'
 
 from .bifrost_tracing import BifrostTracing, BifrostWatcher
-from IPython import get_ipython
+# from IPython import get_ipython
 
 
 
 
-def load_ipython_extension(ipython):
-    ipython.register_magics(BifrostTracing)
-    vw = BifrostWatcher(ipython)
-    ipython.events.register('post_run_cell', vw.post_run_cell)
+# def load_ipython_extension(ipython):
+#     ipython.register_magics(BifrostTracing)
+#     vw = BifrostWatcher(ipython)
+#     ipython.events.register('post_run_cell', vw.post_run_cell)
+#     return vw
 
 
-load_ipython_extension(get_ipython())
+# Watcher = load_ipython_extension(get_ipython())


### PR DESCRIPTION
**Added basic support for `bifrost.plot()` df and output variable tracing. This allows the "Export Code" feature to use the correct variable names instead of defaulting to df, and will allow us to update the output variable when the user applies changes.**


## Improvements
This current implementation is a great proof of concept. However its extensibility is minimal. The variables exist on the Visitors, so any additional variables have to be added manually. We might be able to improve this by passing the Bifrost watcher a search schema. The variable search might look something like this:

### Schema
```
{
assignment:
{target: "Assign",
resolver: lambda node: ...,
visit: {
dataframe_names: {target: "Name", resolver: ..., visit: {...}}
dataframe_functions: {target: "Attribute", resolver:..., visit: {...}}
}

}
```

The resolver functions take in an ast node and produce two things: the data processed from the current node, and the inputs of the keys in the next `visit` block. The type syntax might look something like this in TS: `(node: ast) => {data: any, visit: {[name: string] : ast}}.  For example, above the resolver for `assignment` would produce an object like this:

```
{ data: null,
visit: {
dataframe_names: node
dataframe_functions: node
}
}
```

for processing by the resolvers in the two visit categories.

### Output
```
{
assignment: {
   data: any,
  dataframe_names: {data:any, ...}
  dataframe_functions: {data:any, ...}

}
}
```

We could traverse the output and easily get what we are looking for without having to create new specialized visitors every time we want to change the schema.